### PR TITLE
Fix ie11 svg logo height on search page

### DIFF
--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -6081,7 +6081,9 @@ input[type="text"]:-ms-input-placeholder {
   display: block;
   width: 100%;
   height: 100%;
-  fill: currentColor; }
+  fill: currentColor;
+  /* ie11 compatibility fix here */
+  max-height: 59px; }
 
 /* Container */
 @media (min-width: 1200px) {

--- a/hkm/static/hkm/scss/_app.scss
+++ b/hkm/static/hkm/scss/_app.scss
@@ -120,6 +120,8 @@ color: #555 !important;
   width: 100%;
   height: 100%;
   fill: currentColor;
+  /* ie11 compatibility fix here */
+  max-height: 59px;
 }
 
 /* Container */


### PR DESCRIPTION
add max-height to svg-icon which should fix ie11 issues

refs HEL-161