### PR TITLE
Remove whitespaces from last_record_browsed item in localstorage

### DIFF
--- a/hkm/static/hkm/js/hkm-v2.js
+++ b/hkm/static/hkm/js/hkm-v2.js
@@ -165,9 +165,10 @@ palikka
   function scrollToLastItem() {
 
     var itemId = localStorage.getItem("last_record_browsed") || "_";
+    // Remove white spaces in case of multiple search keywords
+    itemId = itemId.replace(' ', '_');
     var $item = $("[name="+itemId+"]");
     if($item.length) {
-
       $('html, body').animate({
         scrollTop: $item.offset().top
       }, 1000);


### PR DESCRIPTION
If "last_record_browsed" value in localstorage contains whitespaces,
it causes syntax error when building a name attribute. So replace
possible whitespaces with underscores to fix the problem.