### PR TITLE
Few bugfixes for zero price orders and logging

### DIFF
--- a/hkm/printmotor_client.py
+++ b/hkm/printmotor_client.py
@@ -66,7 +66,7 @@ class PrintmotorClient(object):
             LOG.debug(r.status_code)
             return r.status_code
         except requests.exceptions.RequestException as e:
-            LOG.error(e, exc_info=True, extra={'data': {'order_hash': order_collection.pk}})
+            LOG.error(e, exc_info=True, extra={'data': {'order_hash': order_collection.order_hash}})
             return None
 
 

--- a/hkm/views/checkout.py
+++ b/hkm/views/checkout.py
@@ -80,7 +80,7 @@ class OrderSummaryView(TemplateView):
 
             # If order total price is 0, skip payment api and redirect straight to confirmation view
             if order_collection.is_zero_price:
-                return redirect(reverse('hkm_order_confirmation', kwargs={"order_id": order_collection.pk}))
+                return redirect(reverse('hkm_order_confirmation', kwargs={"order_id": order_collection.order_hash}))
 
             redirect_url = order_collection.checkout()
             if redirect_url:


### PR DESCRIPTION
Use ProductOrderCollection order_hash value as order_id when
redirecting to confirmation view with zero priced orders.