### PR TITLE
Align basket quantity texts

### DIFF
--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -5917,7 +5917,8 @@ a.btn-delete-row {
     padding-left: 30px; }
   .basket-metadata {
     align-self: flex-start;
-    max-width: 420px;
+    text-align: center;
+    width: 420px;
     margin-left: -3%; }
     .basket-metadata p {
       font-size: 16px; }

--- a/hkm/static/hkm/scss/_basket-page.scss
+++ b/hkm/static/hkm/scss/_basket-page.scss
@@ -91,7 +91,8 @@ a.btn-delete-row {
 
     &-metadata {
         align-self: flex-start;
-        max-width: 420px;
+        text-align: center;
+        width: 420px;
         margin-left: -3%;
 
         p {


### PR DESCRIPTION
Specify a width for basket line text because basket rows uses
flex and the line text can have different lengths. So
justify-content: space-between has always the same width for the
basket line text and this way quantity divs are displayed in the
same place on every row.