### PR TITLE
Add margin-top value for search button

### DIFF
--- a/hkm/static/hkm/css/main.css
+++ b/hkm/static/hkm/css/main.css
@@ -7054,7 +7054,8 @@ div.grid__fav.active {
   border-width: 2px;
   border-color: #00C281;
   padding: 5px;
-  vertical-align: middle; }
+  vertical-align: middle;
+  margin-top: 1px; }
 
 @media (max-width: 1099px) {
   .nav-search-form__desktop {

--- a/hkm/static/hkm/scss/_app.scss
+++ b/hkm/static/hkm/scss/_app.scss
@@ -1258,6 +1258,7 @@ div.grid__fav.active {
   border-color: $color-hkm-green;
   padding: 5px;
   vertical-align: middle;
+  margin-top: 1px;
 }
 
 .form-control {


### PR DESCRIPTION
This fixes 1 pixel button misalignment in chrome. Firefox and
chrome displays now button correctly aligned.